### PR TITLE
Increase slide separation to cater for smaller screens

### DIFF
--- a/RSEConUK2019-Cylc-Talk/index.html
+++ b/RSEConUK2019-Cylc-Talk/index.html
@@ -78,7 +78,7 @@
     <div
       id="introduction-to-cylc"
       class="step"
-      data-rel-y="1h"
+      data-rel-y="1.3h"
       data-rel-to="title-slide"
     >
       <b>Introduction</b> to Cylc
@@ -87,7 +87,7 @@
     <div
       id="simple-workflow"
       class="step full vflex"
-      data-rel-x="1.2w"
+      data-rel-x="1.3w"
       data-rel-y="0"
     >
       <p>
@@ -402,7 +402,7 @@
     <div
       id="usage-and-community"
       class="step full vflex"
-      data-rel-y="1h"
+      data-rel-y="1.3h"
       data-rel-to="introduction-to-cylc"
       >
       <p>
@@ -422,7 +422,7 @@
     <div
       id="major-sites-map"
       class="step full vflex"
-      data-rel-x="1w"
+      data-rel-x="1.3w"
       data-rel-y="0"
        >
       <p><em>International</em>
@@ -789,7 +789,7 @@
     <div
       id="future-cylc-8"
       class="step full"
-      data-rel-y="1h"
+      data-rel-y="1.3h"
       data-rel-to="usage-and-community"
       >
       <p style="align:left">
@@ -817,7 +817,7 @@
     <div
       id="new-tech-stack"
       class="step"
-      data-rel-x="1w"
+      data-rel-x="1.3w"
       data-rel-y="0"
       >
       <p>Same <i>concept</i>, <em>revised tech stack</em>:</p>
@@ -991,7 +991,7 @@
       id="the-present"
       class="step"
       data-rel-x="0"
-      data-rel-y="1h"
+      data-rel-y="1.3h"
       data-rel-to="future-cylc-8"
       >
       The <b>Present</b>: for now...
@@ -1000,7 +1000,7 @@
     <div
       id="how-to-install"
       class="step vflex"
-      data-rel-x="1w"
+      data-rel-x="1.3w"
       data-rel-y="0"
       >
       <ul>


### PR DESCRIPTION
As discussed offline. Assuming my laptop screen size is fairly standard dimensions for a laptop, which is quite a good assumption in my life experience of laptop sizes, this ``1``-> ``1.3`` for the ``data-rel-`` attributes is a good choice:

* increased to accommodate such smaller screens;
* as tested, does have negative effects for my desktop screen, again fairly typical in dimension;
* still allows the road image from the 'future-cylc-8' slide to show through the bottom of that slide to open out onto the 'the-present' slide, which is an effect I like & want to keep if possible.