### PR TITLE
animation: remove font animation

### DIFF
--- a/RSEConUK2019-Cylc-Talk/css/global-stylesheet.css
+++ b/RSEConUK2019-Cylc-Talk/css/global-stylesheet.css
@@ -198,7 +198,6 @@ body.impress-mouse-timeout {
             0px 0px;
         background-repeat:
             no-repeat;
-        color: white;
     }
     100% {
         /* state after the animation (~same as {body}) */
@@ -241,7 +240,6 @@ body.impress-mouse-timeout {
             0px 0px;
         background-repeat:
             no-repeat;
-        color: black;
     }
 }
 
@@ -280,6 +278,8 @@ body.impress-mouse-timeout {
         0px 0px;
     background-repeat:
         no-repeat;
+}
+#title-slide {
     color: white;
 }
 


### PR DESCRIPTION
The interaction of CSS animation keyframes and the underling Impress.js animation systems is somewhat complicated, easy solution, just don't animate the text colour.