### PR TITLE
Change locations of JS script tags for ensured order

### DIFF
--- a/RSEConUK2019-Cylc-Talk/index.html
+++ b/RSEConUK2019-Cylc-Talk/index.html
@@ -26,6 +26,18 @@
   <script type="text/javascript" src="js/jquery.min.js"></script>
   <script type="text/javascript" src="js/index.js"></script>
   <script type="text/javascript" src="js/minicylc.js"></script>
+
+  <!-- Scripts for section 2-->
+  <!-- For OpenLayers map: 1 & 2) general source JS: bundled -->
+  <script src="js/openlayers-polyfill.js"></script>
+  <script src="js/openlayers-core.min.js"></script>
+  <!-- Plotly 1) bundled core plotly JS script -->
+  <script type="text/javascript" src="js/plotly-latest.min.js"></script>
+  <!-- Plotly: 2) custom JS for MO research running workflows plot:
+       the data for the plot, stored separately to the plotting script: -->
+  <script type="text/javascript"
+   src="js/data/running_workflows_data.js"></script>
+
 </head>
 
 <body class="impress-not-supported">
@@ -35,7 +47,6 @@
   </div>
 
   <div id="impress">
-
 
     <!-- Title -->
     <div
@@ -563,17 +574,13 @@
       id="running-workflows-plot"
       class="step full vflex"
       >
-      <!-- Plotly 1) bundled core plotly JS script -->
-      <script type="text/javascript" src="js/plotly-latest.min.js"></script>
-
       <div id="running-workflows-plotted"></div>
-      <!-- Plotly: 2) custom JS for MO research running workflows plot... -->
-      <!-- the data for the plot, stored separately to the plotting script: -->
+
+      <!-- Plotly: 3) custom JS for MO research running workflows plot:
+           & the script to process the data above & renders it on a plot: -->
       <script type="text/javascript"
-        src="js/data/running_workflows_data.js"></script>
-      <!-- & the script to process the data above & renders it on a plot: -->
-      <script type="text/javascript"
-        src="js/running-workflows-mo-research-plot.js"></script>
+       src="js/running-workflows-mo-research-plot.js"></script>
+
       <ul style="font-size:0.8em">
         <li><em>&gt; 500 consistently</em> since June</li>
         <li>a general <em>upward trend</em> (ignoring noise)</li>
@@ -1136,9 +1143,6 @@
   <script src="js/impress.js"></script>
   <script>impress().init();</script>
 
-  <!-- For OpenLayers map: 2) general source JS: grab scripts from source -->
-  <script src="js/openlayers-polyfill.js"></script>
-  <script src="js/openlayers-core.min.js"></script>
   <!-- For OpenLayers map: 3) custom JS script to create customised map -->
   <script type="text/javascript" src="js/sites-map.js"></script>
 


### PR DESCRIPTION
This seems to fix the error that appears briefly on loading of the slides, for me at least (with logical reasoning). Let me know if you see it or not now, thanks.